### PR TITLE
Fix update_script to use correct request model

### DIFF
--- a/src/ecsapi/_api.py
+++ b/src/ecsapi/_api.py
@@ -661,9 +661,7 @@ class Api:
         windows: Optional[bool],
         timeout: int = None,
     ):
-        body = _CloudScriptUpdateRequest(
-            title=title, content=content, windows=windows
-        )
+        body = _CloudScriptUpdateRequest(title=title, content=content, windows=windows)
         response = self.__patch(
             f"{self.__generate_base_url()}/scripts/{script_id}",
             body=body.model_dump(),

--- a/src/ecsapi/_api.py
+++ b/src/ecsapi/_api.py
@@ -10,6 +10,7 @@ from ._cloud_script import (
     _CloudScriptRetrieveResponse,
     _CloudScriptCreateRequest,
     _CloudScriptCreateResponse,
+    _CloudScriptUpdateRequest,
     _CloudScriptUpdateResponse,
 )
 from ._image import (
@@ -655,12 +656,14 @@ class Api:
     def update_script(
         self,
         script_id: int,
-        title: str,
-        content: str,
-        windows: bool,
+        title: Optional[str],
+        content: Optional[str],
+        windows: Optional[bool],
         timeout: int = None,
     ):
-        body = _CloudScriptCreateRequest(title=title, content=content, windows=windows)
+        body = _CloudScriptUpdateRequest(
+            title=title, content=content, windows=windows
+        )
         response = self.__patch(
             f"{self.__generate_base_url()}/scripts/{script_id}",
             body=body.model_dump(),

--- a/tests/test__api.py
+++ b/tests/test__api.py
@@ -719,6 +719,13 @@ def test_Api_update_script():
     assert True
 
 
+def test_Api_update_script_optional_params():
+    api = get_api()
+    with HTTMock(mock_cloud_script_update_response):
+        api.update_script(15, None, None, None)
+    assert True
+
+
 def test_Api_delete_script():
     api = get_api()
     with HTTMock(mock_cloud_script_delete_response):


### PR DESCRIPTION
## Summary
- handle optional fields in `update_script`
- cover optional params case in tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6877b752da008321a702410c9bb1a161